### PR TITLE
Fix line count of jupyter notebooks

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.ipynb text


### PR DESCRIPTION
This PR makes notebooks counting as text, since this is a python package and notebooks are used for documentation.