### PR TITLE
Add metrics for meshes

### DIFF
--- a/geomfum/metric/mesh.py
+++ b/geomfum/metric/mesh.py
@@ -93,7 +93,7 @@ class EuclideanMetric(BaseMetric):
         return self.dist(np.arange(self._shape.n_vertices))[0]
 
 
-class Dijkstra(BaseMetric):
+class DijkstraMetric(BaseMetric):
     """Shortest path on edge graph of mesh with single source Dijkstra.
 
     Parameters
@@ -243,7 +243,7 @@ class Dijkstra(BaseMetric):
 
 
 
-class FixedNeighborsDijkstra(Dijkstra):
+class FixedNeighborsDijkstra(DijkstraMetric):
     """Shortest path on edge graph of mesh with Dijkstra.
 
     Parameters

--- a/geomfum/metric/mesh.py
+++ b/geomfum/metric/mesh.py
@@ -36,9 +36,9 @@ class BaseMetric(abc.ABC):
         Parameters
         ----------
         point_a : array-like, shape=[...]
-            Point.
+            Index Point.
         point_b : array-like, shape=[...]
-            Other point.
+            Index Point.
 
         Returns
         -------
@@ -68,6 +68,21 @@ class EuclideanMetric(BaseMetric):
         vertices = self._shape.vertices
         diff = vertices[point_a] - vertices[point_b]
         return np.linalg.norm(diff, axis=diff.ndim - 1)
+
+    def dist_matrix(self):
+        """Distance between mesh vertices.
+        
+        Returns
+        -------
+        dist_matrix : array-like, shape=[n_vertices, n_vertices]
+            Distance matrix.
+        """
+        
+        vertices = self._shape.vertices
+        dist_matrix = np.sqrt(np.sum((vertices[:, np.newaxis, :] - 
+                                vertices[np.newaxis, :, :]) ** 2, axis=2))
+
+        return dist_matrix
 
 
 class SingleSourceDijkstra(BaseMetric):
@@ -202,9 +217,7 @@ class SingleSourceDijkstra(BaseMetric):
         """
         if point_b is None:
             return self._dist_no_target(point_a)
-
         return self._dist_target(point_a, point_b)
-
 
 class FixedNeighborsSingleSourceDijkstra(SingleSourceDijkstra):
     """Shortest path on edge graph of mesh with single source Dijkstra.

--- a/geomfum/metric/mesh.py
+++ b/geomfum/metric/mesh.py
@@ -1,0 +1,167 @@
+import networkx as nx
+import numpy as np
+
+
+class EuclideanMetric:
+    def __init__(self, shape):
+        self._shape = shape
+
+    def dist(self, source_index, target_index):
+        """Distance between mesh vertices.
+
+        Parameters
+        ----------
+        source_index : array-like, shape=[...]
+            Index of source point.
+        target_index : array-like, shape=[...]
+            Index of target point.
+
+        Returns
+        -------
+        dist : array-like, shape=[...,]
+            Distance.
+        """
+        # TODO: do against all if target index is None?
+        # TODO: add euclidean with cutoff
+        vertices = self._shape.vertices
+        diff = vertices[source_index] - vertices[target_index]
+        return np.linalg.norm(diff, axis=diff.ndim - 1)
+
+
+class SingleSourceDijkstra:
+    def __init__(self, shape, cutoff=None):
+        self.cutoff = cutoff
+
+        self._shape = shape
+        self._euc_metric = EuclideanMetric(shape)
+        self._graph = self._to_nx_edge_graph()
+
+    def _to_nx_edge_graph(self):
+        edges = self._shape.edges
+        vertex_a, vertex_b = edges.T
+        lengths = self._euc_metric.dist(vertex_a, vertex_b)
+
+        weighted_edges = list(zip(vertex_a, vertex_b, lengths))
+
+        graph = nx.Graph()
+        graph.add_weighted_edges_from(weighted_edges)
+
+        return graph
+
+    def _dist_no_target_single(self, source_index):
+        """Distance between mesh vertices.
+
+        Parameters
+        ----------
+        source_index : array-like, shape=()
+            Index of source point.
+
+        Returns
+        -------
+        dist : array-like, shape=[n_targets]
+            Distance.
+        target_index : array-like, shape=[n_targets,]
+            Target index.
+        """
+        dist_dict = nx.single_source_dijkstra_path_length(
+            self._graph, source_index, cutoff=self.cutoff, weight="weight"
+        )
+        return np.array(list(dist_dict.values())), np.array(list(dist_dict.keys()))
+
+    def _dist_no_target(self, source_index):
+        """Distance between mesh vertices.
+
+        Parameters
+        ----------
+        source_index : array-like, shape=[...]
+            Index of source point.
+
+        Returns
+        -------
+        dist : array-like, shape=[...,] or list[array-like]
+            Distance.
+        target_index : array-like, shape=[n_targets,] or list[array-like]
+            Target index.
+        """
+        if source_index.ndim == 0:
+            return self._dist_no_target_single(source_index)
+
+        out = [
+            self._dist_no_target_single(source_index_) for source_index_ in source_index
+        ]
+        return list(zip(*out))
+
+    def _dist_target_single(self, source_index, target_index):
+        """Distance between mesh vertices.
+
+        Parameters
+        ----------
+        source_index : array-like, shape=()
+            Index of source point.
+        target_index : array-like, shape=()
+            Index of target point.
+
+        Returns
+        -------
+        dist : numeric
+            Distance.
+        """
+        try:
+            dist, _ = nx.single_source_dijkstra(
+                self._graph,
+                source_index,
+                target=target_index,
+                cutoff=self.cutoff,
+                weight="weight",
+            )
+        except nx.NetworkXNoPath:
+            dist = np.inf
+        return dist
+
+    def _dist_target(self, source_index, target_index):
+        """Distance between mesh vertices.
+
+        Parameters
+        ----------
+        source_index : array-like, shape=[...]
+            Index of source point.
+        target_index : array-like, shape=[...]
+            Index of target point.
+
+        Returns
+        -------
+        dist : array-like, shape=[...,]
+            Distance.
+        """
+        if source_index.ndim == 0 and target_index.ndim == 0:
+            return self._dist_target_single(source_index, target_index)
+
+        source_index, target_index = np.broadcast_arrays(source_index, target_index)
+        return np.stack(
+            [
+                self._dist_target_single(source_index_, target_index_)
+                for source_index_, target_index_ in zip(source_index, target_index)
+            ]
+        )
+
+    def dist(self, source_index, target_index=None):
+        """Distance between mesh vertices.
+
+        Parameters
+        ----------
+        source_index : array-like, shape=[...]
+            Index of source point.
+        target_index : array-like, shape=[...]
+            Index of target point.
+
+        Returns
+        -------
+        dist : array-like, shape=[...,] or list[array-like]
+            Distance.
+        target_index : array-like, shape=[n_targets,] or list[array-like]
+            Target index. If `target_index` is None.
+        """
+        if target_index is None:
+            return self._dist_no_target(source_index)
+
+        return self._dist_target(source_index, target_index)

--- a/geomfum/metric/mesh.py
+++ b/geomfum/metric/mesh.py
@@ -71,6 +71,16 @@ class EuclideanMetric(BaseMetric):
 
 
 class SingleSourceDijkstra(BaseMetric):
+    """Shortest path on edge graph of mesh with single source Dijkstra.
+
+    Parameters
+    ----------
+    shape : Shape
+        Shape.
+    cutoff : float
+        Length (sum of edge weights) at which the search is stopped.
+    """
+
     def __init__(self, shape, cutoff=None):
         self.cutoff = cutoff
 
@@ -135,14 +145,12 @@ class SingleSourceDijkstra(BaseMetric):
         dist : numeric
             Distance.
         """
-        # TODO: reconsider behavior with inf
-
         try:
             dist, _ = nx.single_source_dijkstra(
                 self._graph,
                 point_a,
                 target=point_b,
-                cutoff=self.cutoff,
+                cutoff=None,
                 weight="weight",
             )
         except nx.NetworkXNoPath:
@@ -199,7 +207,7 @@ class SingleSourceDijkstra(BaseMetric):
 
 
 class FixedNeighborsSingleSourceDijkstra(SingleSourceDijkstra):
-    """Shortest path with single source Dijkstra.
+    """Shortest path on edge graph of mesh with single source Dijkstra.
 
     Parameters
     ----------

--- a/geomfum/numerics/graph.py
+++ b/geomfum/numerics/graph.py
@@ -1,0 +1,47 @@
+import heapq
+
+from networkx.algorithms.shortest_paths.weighted import _weight_function
+
+
+def single_source_partial_dijkstra_path_length(graph, source, k, weight="weight"):
+    """Compute shortest-path distances from a source node to the k closest nodes.
+
+    Based on cumulative path cost, using an early-stopped Dijkstra's algorithm.
+
+    The search terminates once k nodes (including the source itself) have been reached.
+
+    Parameters
+    ----------
+    graph : networkx.Graph
+        The input graph. Can be directed or undirected.
+        Edge weights must be non-negative.
+    source : node
+        The starting node for paths.
+    k : int
+        Number of nodes to find distances to (including the source itself).
+
+    Returns
+    -------
+    length : dict
+        Dict keyed by node to shortest path length from source.
+    """
+    heap = [(0, source)]
+    visited = set()
+    length = {}
+
+    weight = _weight_function(graph, weight)
+
+    while heap and len(length) < k:
+        dist_u, u = heapq.heappop(heap)
+        if u in visited:
+            continue
+
+        visited.add(u)
+        length[u] = dist_u
+
+        for v, edata in graph[u].items():
+            if v not in visited:
+                w = edata.get(weight)
+                heapq.heappush(heap, (dist_u + w, v))
+
+    return length

--- a/geomfum/shape/mesh.py
+++ b/geomfum/shape/mesh.py
@@ -87,9 +87,7 @@ class TriangleMesh(Shape):
         -------
         edges : array-like, shape=[n_edges, 2]
         """
-        #TO DO: avoid using numpy (torch alternative?)
         if self._edges is None:
-            
             I = np.concatenate([self.faces[:, 0], self.faces[:, 1], self.faces[:, 2]])
             J = np.concatenate([self.faces[:, 1], self.faces[:, 2], self.faces[:, 0]])
 
@@ -97,14 +95,18 @@ class TriangleMesh(Shape):
             Jn = np.concatenate([J, I])
             Vn = np.ones_like(In)
 
-            M = scipy.sparse.csr_matrix((Vn, (In, Jn)), shape=(self.n_vertices, self.n_vertices)).tocoo()
+            M = scipy.sparse.csr_matrix(
+                (Vn, (In, Jn)), shape=(self.n_vertices, self.n_vertices)
+            ).tocoo()
 
             edges0 = M.row
             edges1 = M.col
 
             indices = M.col > M.row
 
-            self._edges = np.concatenate([edges0[indices, None], edges1[indices, None]], axis=1)
+            self._edges = np.concatenate(
+                [edges0[indices, None], edges1[indices, None]], axis=1
+            )
         return self._edges
 
     @property

--- a/geomfum/shape/mesh.py
+++ b/geomfum/shape/mesh.py
@@ -3,6 +3,9 @@
 import numpy as np
 import scipy
 
+# TODO: remove ASAP
+from pyFM.mesh.geometry import edges_from_faces
+
 from geomfum.io import load_mesh
 from geomfum.operator import (
     FaceDivergenceOperator,
@@ -29,6 +32,7 @@ class TriangleMesh(Shape):
         self.vertices = vertices
         self.faces = faces
 
+        self._edges = None
         self._face_normals = None
         self._face_areas = None
         self._vertex_areas = None
@@ -77,6 +81,18 @@ class TriangleMesh(Shape):
         n_faces : int
         """
         return self.faces.shape[0]
+
+    @property
+    def edges(self):
+        """Edges of the mesh.
+
+        Returns
+        -------
+        edges : array-like, shape=[n_edges, 2]
+        """
+        if self._edges is None:
+            self._edges = edges_from_faces(self.faces)
+        return self._edges
 
     @property
     def face_normals(self):


### PR DESCRIPTION
Inspired by #9, this PR brings in the first metrics for meshes (very preliminary design!).


**Why?** tldr: modularization!

An important step of scalable FMaps [(Magnet, 2023)](https://onlinelibrary.wiley.com/doi/full/10.1111/cgf.14746) consists of approximating the Laplace-Beltrami eigenbasis.

An important step for approximating the Laplace-Beltrami eigenbasis is the construction of local basis functions [(Nasikun, 2018)](https://onlinelibrary.wiley.com/doi/full/10.1111/cgf.13496).

An important step for the construction of local basis functions is the computation of distances between sampling points and the original mesh.

There's multiple ways of computing distances given a mesh.
I'm providing a common interface to compute those distances.
For now, I've implemented the `EuclideanMetric` and the `SingleSourceDijkstra`. Variants of the second are low hanging fruits. [(Magnet, 2023)](https://onlinelibrary.wiley.com/doi/full/10.1111/cgf.14746) implements a variant of `SingleSourceDijkstra`.

I hope this thread helps  understanding a bit better the modularization steps I've started taking on scalable refactoring (https://github.com/luisfpereira/geomfum/commit/51f6f50cb5da2c2e1d3a1046149763a8d13e6b9a).


Of course I'm justifying this PR with scalable because it is the implementation we're pursuing at the moment requiring this, but needlessly to say these metrics will find a lot of applicability (e.g. the distance-based samplers we're discussing yesterday).


Other goals this PR will lead to: implementation of [(Nasikun, 2018)](https://onlinelibrary.wiley.com/doi/full/10.1111/cgf.13496).


Still a draft because I need to think a bit more about the design and add other metrics.
Looking for your feedback @GiLonga, @gviga.