### PR TITLE
Make spectral descriptor receive shape instead of basis

### DIFF
--- a/geomfum/basis.py
+++ b/geomfum/basis.py
@@ -186,14 +186,3 @@ class LaplaceEigenBasis(EigenBasis):
             self.vecs.T,
             la.matvecmul(self._shape.laplacian.mass_matrix, array),
         )
-
-    @property
-    def landmark_indices(self):
-        """Landmarks.
-
-        Returns
-        -------
-        landmark_indices : array-like, shape=[n_landmarks]
-            Landmarks.
-        """
-        return self._shape.landmark_indices

--- a/geomfum/descriptor/_base.py
+++ b/geomfum/descriptor/_base.py
@@ -27,13 +27,13 @@ class SpectralDescriptor(Descriptor, abc.ABC):
         self.use_landmarks = use_landmarks
 
     @abc.abstractmethod
-    def __call__(self, basis, domain=None):
+    def __call__(self, shape, domain=None):
         """Compute descriptor.
 
         Parameters
         ----------
-        basis : Eigenbasis.
-            Basis.
+        shape : Shape.
+            Shape.
         domain : array-like, shape=[n_domain]
             Domain points for computation.
         """

--- a/geomfum/descriptor/pipeline.py
+++ b/geomfum/descriptor/pipeline.py
@@ -70,10 +70,7 @@ class DescriptorPipeline:
     def apply(self, shape):
         descr = None
         for step in self.steps:
-            if isinstance(step, SpectralDescriptor):
-                descr = self._update_descr(descr, step(shape.basis))
-
-            elif isinstance(step, Descriptor):
+            if isinstance(step, Descriptor):
                 descr = self._update_descr(descr, step(shape))
 
             elif isinstance(step, Subsampler):
@@ -83,6 +80,6 @@ class DescriptorPipeline:
                 descr = step(shape, descr)
 
             else:
-                raise ValueError("Unkown step type.")
+                raise ValueError("Unknown step type.")
 
         return descr

--- a/notebooks/how_to/descriptors.ipynb
+++ b/notebooks/how_to/descriptors.ipynb
@@ -52,7 +52,7 @@
                 {
                     "data": {
                         "text/plain": [
-                            "<geomfum.basis.LaplaceEigenBasis at 0x725b774a8ef0>"
+                            "<geomfum.basis.LaplaceEigenBasis at 0x78d00e101010>"
                         ]
                     },
                     "execution_count": 3,
@@ -94,7 +94,7 @@
                 "    scaled=True, n_domain=3, use_landmarks=False\n",
                 ")\n",
                 "\n",
-                "hsign = heat_signature(mesh.basis)\n",
+                "hsign = heat_signature(mesh)\n",
                 "\n",
                 "hsign.shape"
             ]
@@ -123,7 +123,7 @@
                 }
             ],
             "source": [
-                "hsign = heat_signature(mesh.basis, domain=np.array([0.2, 0.3]))\n",
+                "hsign = heat_signature(mesh, domain=np.array([0.2, 0.3]))\n",
                 "\n",
                 "hsign.shape"
             ]
@@ -156,7 +156,7 @@
                 "\n",
                 "heat_signature.use_landmarks = True\n",
                 "\n",
-                "hsign = heat_signature(mesh.basis)\n",
+                "hsign = heat_signature(mesh)\n",
                 "\n",
                 "hsign.shape"
             ]
@@ -194,7 +194,7 @@
             "source": [
                 "wave_signature = WaveKernelSignature.from_registry(n_domain=5)\n",
                 "\n",
-                "wsign = wave_signature(mesh.basis)\n",
+                "wsign = wave_signature(mesh)\n",
                 "\n",
                 "wsign.shape"
             ]

--- a/tests/cases/pyfm.py
+++ b/tests/cases/pyfm.py
@@ -14,7 +14,7 @@ class SpectralDescriptorCmpCase(TestCase):
     # TODO: add also descriptor batch?
 
     def test_descriptor_cmp(self, shape, pyfm_shape, atol, domain=None):
-        descr = self.descriptor(shape.basis, domain=domain)
+        descr = self.descriptor(shape, domain=domain)
         pyfm_descr = self.pyfm_descriptor(pyfm_shape, domain=domain)
 
         self.assertAllClose(descr, pyfm_descr.T, atol=atol)


### PR DESCRIPTION
This PR makes `SpectralDescriptor` handle shapes, instead of basis. This is motivated by and closes #22.
In the initial design, the idea was to avoid passing unnecessary information to the descriptor computation. The need to access landmark indices shows we care also about the shape (not only the basis).