### PR TITLE
DIscrete Optimization, Smooth Functional Maps, Bijective ZoomOut

### DIFF
--- a/geomfum/convert.py
+++ b/geomfum/convert.py
@@ -105,7 +105,6 @@ class DiscreteOptimizationP2pFromFmConverter(BaseP2pFromFmConverter):
 
         self.neighbor_finder = neighbor_finder
         self.bijective = bijective
-        self.adjoint = adjoint
         self.energies = energies
         
     def __call__(self, fmap_matrix, basis_a, basis_b, descr_a, descr_b):
@@ -132,16 +131,14 @@ class DiscreteOptimizationP2pFromFmConverter(BaseP2pFromFmConverter):
         if 'adjoint' in self.energies:
             emb_a.append(basis_a.full_vecs[:, :k1])
             emb_b.append(basis_b.full_vecs[:, :k2] @ fmap_matrix)
-        #if 'bijective' in self.energies:
-        #    emb_a.append(basis_a.full_vecs[:, :k1] @ fmap_matrix)
-        #    emb_b.append(basis_b.full_vecs[:, :k2])
         if 'conformal' in self.energies:
-            emb_a.append(basis_a.full_vecs[:, :k1] @ (basis_a.full_evals[:, :k1][:, None] * fmap_matrix.T))
+            emb_a.append(basis_a.full_vecs[:, :k1] @ (basis_a.full_vals[:k1][:, None] * fmap_matrix.T))
             emb_b.append(basis_b.full_vecs[:, :k2])
         if 'descriptors' in self.energies:
-            emb_a.append(basis_a.full_vecs[:, :k1] @ basis_a.project(descr_a))
-            emb_b.append(basis_b.full_vecs[:, :k2] @ basis_b.project(descr_b))
+            emb_a.append(basis_a.full_vecs[:, :k1] @ basis_a.project(descr_a).T)
+            emb_b.append(basis_b.full_vecs[:, :k2] @ basis_b.project(descr_b).T)
 
+        #TODO: add bijective zoomout
         
         emb1 = np.concatenate(emb_a, axis=1)
         emb2 = np.concatenate(emb_b, axis=1)

--- a/geomfum/convert.py
+++ b/geomfum/convert.py
@@ -9,7 +9,6 @@ import numpy as np
 class BaseP2pFromFmConverter(abc.ABC):
     """Pointwise map from functional map."""
 
-
 class P2pFromFmConverter(BaseP2pFromFmConverter):
     """Pointwise map from functional map.
 
@@ -46,7 +45,7 @@ class P2pFromFmConverter(BaseP2pFromFmConverter):
         self.adjoint = adjoint
         self.bijective = bijective
 
-    def __call__(self, fmap_matrix, basis_a, basis_b):
+    def __call__(self, fmap_matrix_12, basis_a, basis_b):
         """Convert functional map.
 
         Parameters
@@ -59,14 +58,14 @@ class P2pFromFmConverter(BaseP2pFromFmConverter):
         p2p : array-like, shape=[{n_vertices_b, n_vertices_a}]
             Pointwise map. ``bijective`` controls shape.
         """
-        k2, k1 = fmap_matrix.shape
+        k2, k1 = fmap_matrix_12.shape
 
         if self.adjoint:
             emb1 = basis_a.full_vecs[:, :k1]
-            emb2 = basis_b.full_vecs[:, :k2] @ fmap_matrix
+            emb2 = basis_b.full_vecs[:, :k2] @ fmap_matrix_12
 
         else:
-            emb1 = basis_a.full_vecs[:, :k1] @ fmap_matrix.T
+            emb1 = basis_a.full_vecs[:, :k1] @ fmap_matrix_12.T
             emb2 = basis_b.full_vecs[:, :k2]
 
         if self.bijective:
@@ -75,101 +74,28 @@ class P2pFromFmConverter(BaseP2pFromFmConverter):
         self.neighbor_finder.fit(emb1)
         _, p2p_21 = self.neighbor_finder.kneighbors(emb2)
 
+    
         return p2p_21[:, 0]
 
-class DiscreteOptimizationP2pFromFmConverter(BaseP2pFromFmConverter):
-    """Discrete optimization pointwise map from functional map.
-
+class BijectiveP2pFromFmConverter(BaseP2pFromFmConverter):
+ 
+    """ Bijective pointwise maps from functional maps.
+    
     Parameters
     ----------
     neighbor_finder : NeighborFinder
         Nearest neighbor finder.
-    bijective : bool
-        Whether to use bijective method. Check [VM2023]_.
+    adjoint : bool
+        Whether to use adjoint method.
 
     References
     ----------
-    .. [RMWO2021] Jing Ren, Simone Melzi, Peter Wonka, Maks Ovsjanikov.
-        “Discrete Optimization for Shape Matching.” Eurographics Symposium
-        on Geometry Processing 2021, K. Crane and J. Digne (Guest Editors),
-        Volume 40 (2021), Number 5. 
+    .. [RMOW2023] Jing Ren, Simone Melzi, Maks Ovsjanikov, Peter Wonka.
+        "MapTree: Recovering Multiple Solutions in the Space of Maps."
+        ACM Transactions on Graphics 42, no. 4 (2023): 1-15.
     """
 
-    def __init__(self, neighbor_finder=None, adjoint=False, bijective=False, energies=['ortho','adjoint','conformal','descriptors']):
-        if neighbor_finder is None:
-            neighbor_finder = NearestNeighbors(
-                n_neighbors=1, leaf_size=40, algorithm="kd_tree", n_jobs=1
-            )
-        if neighbor_finder.n_neighbors > 1:
-            raise ValueError("Expects `n_neighors = 1`.")
-
-        self.neighbor_finder = neighbor_finder
-        self.bijective = bijective
-        self.energies = energies
-        
-    def __call__(self, fmap_matrix, basis_a, basis_b, descr_a, descr_b):
-        """Convert functional map.
-
-        Parameters
-        ----------
-        fmap_matrix : array-like, shape=[spectrum_size_b, spectrum_size_a]
-            Functional map matrix.
-
-        Returns
-        -------
-        p2p : array-like, shape=[{n_vertices_b, n_vertices_a}]
-            Pointwise map. ``bijective`` controls shape.
-        """
-        k2, k1 = fmap_matrix.shape        
-        #embedding concatenation
-        emb_a = []
-        emb_b = []
-
-        if  'ortho' in self.energies:
-            emb_a.append(basis_a.full_vecs[:, :k1] @ fmap_matrix.T)
-            emb_b.append(basis_b.full_vecs[:, :k2])
-        if 'adjoint' in self.energies:
-            emb_a.append(basis_a.full_vecs[:, :k1])
-            emb_b.append(basis_b.full_vecs[:, :k2] @ fmap_matrix)
-        if 'conformal' in self.energies:
-            emb_a.append(basis_a.full_vecs[:, :k1] @ (basis_a.full_vals[:k1][:, None] * fmap_matrix.T))
-            emb_b.append(basis_b.full_vecs[:, :k2])
-        if 'descriptors' in self.energies:
-            emb_a.append(basis_a.full_vecs[:, :k1] @ basis_a.project(descr_a).T)
-            emb_b.append(basis_b.full_vecs[:, :k2] @ basis_b.project(descr_b).T)
-
-        #TODO: add bijective zoomout
-        
-        emb1 = np.concatenate(emb_a, axis=1)
-        emb2 = np.concatenate(emb_b, axis=1)
-        
-        
-        if self.bijective:
-            emb1, emb2 = emb2, emb1
-
-        self.neighbor_finder.fit(emb1)
-        _, p2p_21 = self.neighbor_finder.kneighbors(emb2)
-
-        return p2p_21[:, 0]
-
-class SmoothP2pFromFmConverter(BaseP2pFromFmConverter):
-    """Smooth pointwise map from functional map.
-
-    Parameters
-    ----------
-    neighbor_finder : NeighborFinder
-        Nearest neighbor finder.
-    bijective : bool
-        Whether to use bijective method. Check [VM2023]_.
-
-    References
-    ----------
-    .. [MRSO2022] R. Magnet, J. Ren, O. Sorkine-Hornung, and M. Ovsjanikov.
-        "Smooth NonRigid Shape Matching via Effective Dirichlet Energy Optimization."
-        In 2022 International Conference on 3D Vision (3DV).
-    """
-
-    def __init__(self, neighbor_finder=None, adjoint=False, bijective=False):
+    def __init__(self, neighbor_finder=None, adjoint=False):
         if neighbor_finder is None:
             neighbor_finder = NearestNeighbors(
                 n_neighbors=1, leaf_size=40, algorithm="kd_tree", n_jobs=1
@@ -179,9 +105,157 @@ class SmoothP2pFromFmConverter(BaseP2pFromFmConverter):
 
         self.neighbor_finder = neighbor_finder
         self.adjoint = adjoint
-        self.bijective = bijective
+
+    def __call__(self, fmap_matrix_ab, fmap_matrix_ba, basis_a, basis_b):
+        """Convert functional map.
+
+        Parameters
+        ----------
+        fmap_matrix : array-like, shape=[spectrum_size_b, spectrum_size_a]
+            Functional map matrix.
+
+        Returns
+        -------
+        p2p : array-like, shape=[{n_vertices_b, n_vertices_a}]
+            Pointwise map. ``bijective`` controls shape.
+        """
+        k2, k1 = fmap_matrix_ab.shape
         
-    def __call__(self, fmap_matrix,displ, mesh_a,mesh_b):
+        emb1=[]
+        emb2=[]
+
+        if self.adjoint:
+            emb1.append( basis_a.full_vecs[:, :k1] )
+            emb2.append( basis_b.full_vecs[:, :k2] @ fmap_matrix_ab )
+            
+            emb1.append( basis_a.full_vecs[:, :k1] @ fmap_matrix_ba )
+            emb2.append( basis_b.full_vecs[:, :k2] )
+
+        else:
+            emb1.append( basis_a.full_vecs[:, :k1] @ fmap_matrix_ba.T )
+            emb2.append( basis_b.full_vecs[:, :k2] )
+            
+            emb1.append( basis_a.full_vecs[:, :k1] )
+            emb2.append( basis_b.full_vecs[:, :k2] @ fmap_matrix_ab.T )
+        
+        emb1= np.concatenate(emb1, axis=1)
+        emb2= np.concatenate(emb2, axis=1)
+        
+        self.neighbor_finder.fit(emb1)
+        _, p2p_21 = self.neighbor_finder.kneighbors(emb2)
+
+        emb1, emb2 = emb2, emb1
+
+        self.neighbor_finder.fit(emb1)
+        _, p2p_12 = self.neighbor_finder.kneighbors(emb2)
+        
+        return p2p_21[:, 0], p2p_12[:, 0]
+
+
+class DiscreteOptimizationP2pFromFmConverter(BaseP2pFromFmConverter):
+    """Discrete optimization pointwise map from functional map.
+
+    Parameters
+    ----------
+    neighbor_finder : NeighborFinder
+        Nearest neighbor finder.
+    energies : list of str
+        Energies to use. Options are 'ortho', 'adjoint', 'conformal', and 'descriptors'.
+        
+    References
+    ----------
+    .. [RMWO2021] Jing Ren, Simone Melzi, Peter Wonka, Maks Ovsjanikov.
+        “Discrete Optimization for Shape Matching.” Eurographics Symposium
+        on Geometry Processing 2021, K. Crane and J. Digne (Guest Editors),
+        Volume 40 (2021), Number 5. 
+    """
+
+    def __init__(self, neighbor_finder=None, energies=['ortho','adjoint','conformal','descriptors']):
+        if neighbor_finder is None:
+            neighbor_finder = NearestNeighbors(
+                n_neighbors=1, leaf_size=40, algorithm="kd_tree", n_jobs=1
+            )
+        if neighbor_finder.n_neighbors > 1:
+            raise ValueError("Expects `n_neighors = 1`.")
+
+        self.neighbor_finder = neighbor_finder
+        self.energies = energies
+        
+    def __call__(self, fmap_matrix_12, fmap_matrix_21, basis_a, basis_b, descr_a, descr_b):
+        """Convert functional map.
+
+        Parameters
+        ----------
+        fmap_matrix : array-like, shape=[spectrum_size_b, spectrum_size_a]
+            Functional map matrix.
+
+        Returns
+        -------
+        p2p : array-like, shape=[{n_vertices_b, n_vertices_a}]
+            Pointwise map. ``bijective`` controls shape.
+        """
+        k2, k1 = fmap_matrix_12.shape        
+
+        emb1 = []
+        emb2 = []
+
+        if  'ortho' in self.energies:
+            emb1.append(basis_a.full_vecs[:, :k1] @ fmap_matrix_12.T)
+            emb2.append(basis_b.full_vecs[:, :k2])
+        if 'adjoint' in self.energies:
+            emb1.append(basis_a.full_vecs[:, :k1])
+            emb2.append(basis_b.full_vecs[:, :k2] @ fmap_matrix_12)
+        if 'conformal' in self.energies:
+            emb1.append(basis_a.full_vecs[:, :k1] @ (basis_a.full_vals[:k1][:, None] * fmap_matrix_12.T))
+            emb2.append(basis_b.full_vecs[:, :k2])
+        if 'descriptors' in self.energies:
+            emb1.append(basis_a.full_vecs[:, :k1] @ basis_a.project(descr_a).T)
+            emb2.append(basis_b.full_vecs[:, :k2] @ basis_b.project(descr_b).T)
+        if 'bijective' in self.energies:
+            emb1.append(basis_a.full_vecs[:, :k1] @ fmap_matrix_21)
+            emb2.append(basis_b.full_vecs[:, :k2])
+        
+        emb1 = np.concatenate(emb1, axis=1)
+        emb2 = np.concatenate(emb1, axis=1)
+        
+    
+        self.neighbor_finder.fit(emb1)
+        _, p2p_21 = self.neighbor_finder.kneighbors(emb2)
+
+
+        emb1, emb2 = emb2, emb1
+
+        self.neighbor_finder.fit(emb1)
+        _, p2p_12 = self.neighbor_finder.kneighbors(emb2)
+        
+        return p2p_21[:, 0], p2p_12[:, 0]
+
+class SmoothP2pFromFmConverter(BaseP2pFromFmConverter):
+    """Smooth pointwise map from functional map.
+
+    Parameters
+    ----------
+    neighbor_finder : NeighborFinder
+        Nearest neighbor finder.
+
+    References
+    ----------
+    .. [MRSO2022] R. Magnet, J. Ren, O. Sorkine-Hornung, and M. Ovsjanikov.
+        "Smooth NonRigid Shape Matching via Effective Dirichlet Energy Optimization."
+        In 2022 International Conference on 3D Vision (3DV).
+    """
+
+    def __init__(self, neighbor_finder=None, adjoint=False):
+        if neighbor_finder is None:
+            neighbor_finder = NearestNeighbors(
+                n_neighbors=1, leaf_size=40, algorithm="kd_tree", n_jobs=1
+            )
+        if neighbor_finder.n_neighbors > 1:
+            raise ValueError("Expects `n_neighors = 1`.")
+
+        self.neighbor_finder = neighbor_finder
+        self.adjoint = adjoint
+    def __call__(self, fmap_matrix12, fmap_matrix21, displ21, displ12 , mesh_a,mesh_b):
         """Convert functional map.
 
         Parameters
@@ -199,33 +273,44 @@ class SmoothP2pFromFmConverter(BaseP2pFromFmConverter):
         basis_a = mesh_a.basis
         basis_b = mesh_b.basis
         
-        k2, k1 = fmap_matrix.shape 
-        #embedding concatenation
-        emb_a = []
-        emb_b = []
+        k2, k1 = fmap_matrix12.shape 
+        emb1=[]
+        emb2=[]
 
-        if  self.adjoint:
-            emb_a.append(basis_a.full_vecs[:, :k1])
-            emb_b.append(basis_b.full_vecs[:, :k2] @ fmap_matrix)
+        if self.adjoint:
+            emb1.append( basis_a.full_vecs[:, :k1] )
+            emb2.append( basis_b.full_vecs[:, :k2] @ fmap_matrix12 )
+            
+            emb1.append( basis_a.full_vecs[:, :k1] @ fmap_matrix21 )
+            emb2.append( basis_b.full_vecs[:, :k2] )
+
         else:
-            emb_a.append(basis_a.full_vecs[:, :k1] @ fmap_matrix.T)
-            emb_b.append(basis_b.full_vecs[:, :k2])
-
-        emb_a.append(vert_a)
-        emb_b.append(vert_b+displ)
-        #TODO: add bijective zoomout
+            emb1.append( basis_a.full_vecs[:, :k1] @ fmap_matrix12.T )
+            emb2.append( basis_b.full_vecs[:, :k2] )
+            
+            emb1.append( basis_a.full_vecs[:, :k1] )
+            emb2.append( basis_b.full_vecs[:, :k2] @ fmap_matrix12.T )
+            
+            
+        emb1.append(vert_a)
+        emb2.append(vert_b+displ21)
         
-        emb1 = np.concatenate(emb_a, axis=1)
-        emb2 = np.concatenate(emb_b, axis=1)
+        emb1.append(vert_a+displ12)
+        emb2.append(vert_b)
+                    
+        emb1 = np.concatenate(emb1, axis=1)
+        emb2 = np.concatenate(emb2, axis=1)
         
-        
-        if self.bijective:
-            emb1, emb2 = emb2, emb1
-
         self.neighbor_finder.fit(emb1)
         _, p2p_21 = self.neighbor_finder.kneighbors(emb2)
 
-        return p2p_21[:, 0]
+        emb1, emb2 = emb2, emb1
+
+        self.neighbor_finder.fit(emb1)
+        _, p2p_12 = self.neighbor_finder.kneighbors(emb2)
+        
+        return p2p_21[:, 0], p2p_12[:, 0]
+
 
 class BaseFmFromP2pConverter(abc.ABC):
     """Functional map from pointwise map."""
@@ -339,7 +424,7 @@ class DirichletDisplacementFromP2pConverter(BaseDisplacementFromP2pConverter):
         In 2022 International Conference on 3D Vision (3DV).
     """
     
-    def __init__(self, weight=1.0):
+    def __init__(self, weight=1e3):
         self.weight = weight
     def __call__(self, p2p, mesh_a, mesh_b, stiffness_matrix_b, mass_matrix_b):
         """Convert pointwise map to displacement.    
@@ -366,4 +451,3 @@ class DirichletDisplacementFromP2pConverter(BaseDisplacementFromP2pConverter):
         target = scipy.sparse.linalg.spsolve(stiffness_matrix_b + self.weight *mass_matrix_b, mass_matrix_b @ mesh_a.vertices[p2p])
         
         return target - mesh_b.vertices
-

--- a/geomfum/refine.py
+++ b/geomfum/refine.py
@@ -397,11 +397,14 @@ class DiscreteOptimization(IterativeRefiner):
         k2, k1 = fmap_matrix.shape
         new_k1, new_k2 = k1 + self._step_a, k2 + self._step_b
 
+        basis_a.use_k, basis_b.use_k = k1, k2
         p2p_21 = self.p2p_from_fm_converter(fmap_matrix, basis_a, basis_b, descr_a=descr_a, descr_b=descr_b)
 
         fmap_matrix = self.fm_from_p2p_converter(
             p2p_21, basis_a.truncate(new_k1), basis_b.truncate(new_k2)
         )
+        basis_a.use_k, basis_b.use_k = new_k1, new_k2
+
         return self.iter_refiner(fmap_matrix, basis_a, basis_b)
 
 


### PR DESCRIPTION
This PR introduces three additional refinement methods from:
[1] MapTree: Recovering Multiple Solutions in the Space of Maps (https://arxiv.org/abs/2006.02532)
[2] Discrete Optimization for Shape Matching (https://www.lix.polytechnique.fr/~maks/papers/SGP21_DiscMapOpt.pdf)
[3] Smooth Non-Rigid Shape Matching via Effective Dirichlet Energy Optimization (https://arxiv.org/abs/2210.02870)

Some of these methods extend the conversion modules and refinement modules, needing to create a BijectiveItaretiveRefiner and other modifications of Converters.
[2] can be seen as a generalization of the ZoomOut algorithm. We could think to a redescign in which ZoomOut is a special instance of this algorithm. However, I think it would be cool to have also different implementations and then show that they are equivalent.

In general, we have to discuss whether the current structure of the converter (that takes a FM and return a p2p) can be extended to a common structure that can be used also when we want to input 2FM and return the two p2p in both directions, or it is better to create different converter classes for each purpose.