### PR TITLE
Fix robust Laplacian bug

### DIFF
--- a/geomfum/shape/mesh.py
+++ b/geomfum/shape/mesh.py
@@ -26,8 +26,9 @@ class TriangleMesh(Shape):
 
     def __init__(self, vertices, faces):
         super().__init__(is_mesh=True)
-        self.vertices = vertices
-        self.faces = faces
+        # Ensure vertices and faces are numpy arrays
+        self.vertices = np.asarray(vertices)
+        self.faces = np.asarray(faces)
 
         self._edges = None
         self._face_normals = None

--- a/geomfum/shape/mesh.py
+++ b/geomfum/shape/mesh.py
@@ -26,7 +26,6 @@ class TriangleMesh(Shape):
 
     def __init__(self, vertices, faces):
         super().__init__(is_mesh=True)
-        # Ensure vertices and faces are numpy arrays
         self.vertices = np.asarray(vertices)
         self.faces = np.asarray(faces)
 

--- a/geomfum/shape/point_cloud.py
+++ b/geomfum/shape/point_cloud.py
@@ -1,5 +1,7 @@
 """Definition of point cloud."""
 
+import numpy as np
+
 from geomfum.io import load_pointcloud
 
 from ._base import Shape
@@ -16,7 +18,7 @@ class PointCloud(Shape):
 
     def __init__(self, vertices):
         super().__init__(is_mesh=False)
-        self.vertices = vertices
+        self.vertices = np.asarray(vertices)
 
     @classmethod
     def from_file(cls, filename):

--- a/geomfum/wrap/robust.py
+++ b/geomfum/wrap/robust.py
@@ -1,5 +1,6 @@
 """robust_laplacian wrapper."""
 
+import numpy as np
 import robust_laplacian
 
 from geomfum.laplacian import BaseLaplacianFinder
@@ -32,8 +33,10 @@ class RobustMeshLaplacianFinder(BaseLaplacianFinder):
         mass_matrix : scipy.sparse.csc_matrix, shape=[n_vertices, n_vertices]
             Diagonal lumped mass matrix.
         """
+        vertices = np.array(shape.vertices, dtype=np.float32)
+        faces = np.array(shape.faces, dtype=np.int32)
         return robust_laplacian.mesh_laplacian(
-            shape.vertices, shape.faces, mollify_factor=self.mollify_factor
+            vertices, faces, mollify_factor=self.mollify_factor
         )
 
 

--- a/geomfum/wrap/robust.py
+++ b/geomfum/wrap/robust.py
@@ -70,8 +70,9 @@ class RobustPointCloudLaplacianFinder(BaseLaplacianFinder):
         mass_matrix : scipy.sparse.csc_matrix, shape=[n_vertices, n_vertices]
             Diagonal lumped mass matrix.
         """
+        vertices = np.array(shape.vertices, dtype=np.float32)
         return robust_laplacian.point_cloud_laplacian(
-            shape.vertices,
+            vertices,
             mollify_factor=self.mollify_factor,
             n_neighbors=self.n_neighbors,
         )

--- a/geomfum/wrap/robust.py
+++ b/geomfum/wrap/robust.py
@@ -1,6 +1,5 @@
 """robust_laplacian wrapper."""
 
-import numpy as np
 import robust_laplacian
 
 from geomfum.laplacian import BaseLaplacianFinder
@@ -33,10 +32,8 @@ class RobustMeshLaplacianFinder(BaseLaplacianFinder):
         mass_matrix : scipy.sparse.csc_matrix, shape=[n_vertices, n_vertices]
             Diagonal lumped mass matrix.
         """
-        vertices = np.array(shape.vertices, dtype=np.float32)
-        faces = np.array(shape.faces, dtype=np.int32)
         return robust_laplacian.mesh_laplacian(
-            vertices, faces, mollify_factor=self.mollify_factor
+            shape.vertices, shape.faces, mollify_factor=self.mollify_factor
         )
 
 
@@ -70,9 +67,8 @@ class RobustPointCloudLaplacianFinder(BaseLaplacianFinder):
         mass_matrix : scipy.sparse.csc_matrix, shape=[n_vertices, n_vertices]
             Diagonal lumped mass matrix.
         """
-        vertices = np.array(shape.vertices, dtype=np.float32)
         return robust_laplacian.point_cloud_laplacian(
-            vertices,
+            shape.vertices,
             mollify_factor=self.mollify_factor,
             n_neighbors=self.n_neighbors,
         )


### PR DESCRIPTION
This PR tries to solve #39. 
We must pass numpy array to the robust Laplacian, so we convert attributes before pass them. 
In the future, we will need to improve casting for the attributes to be robust to these errors