### PR TITLE
Remove igl version freezing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ requires-python = ">= 3.9"
 dependencies = ["numpy", "scipy", "scikit-learn", "meshio", "pyfmaps"]
 
 [project.optional-dependencies]
-lapl = ["robust-laplacian", "libigl==2.5.4.dev0"]
+lapl = ["robust-laplacian", "libigl"]
 metric = ["networkx"]
 sampling = ["pymeshlab"]
 opt = ["geomfum[lapl,metric,sampling]"]


### PR DESCRIPTION
Following the latest release of libigl (https://pypi.org/project/libigl/2.6.1/), this PR removes version freezing (done in  https://github.com/luisfpereira/geomfum/commit/cfba458dd5abfe042b772119473742b898ec5d00 for test passing). Something like >2.5 would be better, but let's keep it simple for now.