### PR TITLE
Fps sampler

### DIFF
--- a/geomfum/metric/mesh.py
+++ b/geomfum/metric/mesh.py
@@ -1,4 +1,4 @@
-"""Module that metrics for calcualte distances on a mesh."""
+"""Module containing metrics to calcualte distances on a mesh."""
 
 import abc
 
@@ -307,7 +307,12 @@ class GraphShortestPathMetric(_NxDijkstraMixins, FinitePointSetMetric):
         dist_dict = nx.single_source_dijkstra_path_length(
             self._graph, source_point.item(), cutoff=self.cutoff, weight="weight"
         )
-        return np.array(list(dist_dict.values())), np.array(list(dist_dict.keys()))
+        indices = np.array(list(dist_dict.keys()))
+        distances = np.array(list(dist_dict.values()))
+        sort_order = np.argsort(indices)
+        indices = indices[sort_order]
+        distances = distances[sort_order]
+        return np.array(list(distances)), np.array(list(indices))
 
 
 class KClosestGraphShortestPathMetric(_NxDijkstraMixins, FinitePointSetMetric):

--- a/geomfum/plot.py
+++ b/geomfum/plot.py
@@ -28,6 +28,10 @@ class ShapePlotter(abc.ABC):
     def set_vertex_scalars(self, scalars):
         """Set vertex scalars on mesh."""
         raise NotImplementedError("Not implemented for this plotter.")
+    
+    def highlight_vertices(self, coords, color, size):
+        """Highlight vertices on mesh."""
+        raise NotImplementedError("Not implemented for this plotter.")
 
 
 class MeshPlotter(WhichRegistryMixins, ShapePlotter):

--- a/geomfum/wrap/plotly.py
+++ b/geomfum/wrap/plotly.py
@@ -57,6 +57,30 @@ class PlotlyMeshPlotter(ShapePlotter):
 
         return self
 
+    def highlight_vertices(self, coords, color='red', size=4,):
+        """Highlight vertices on mesh.
+
+        Parameters
+        ----------
+        coords : array-like, shape=[n_vertices, 3]
+            Coordinates of vertices to highlight.
+        color : str
+            Color of the highlighted vertices as str.
+        size : int
+            Size of the highlighted vertices.
+        """
+        name = 'Highlighted_points'
+        marker = go.Scatter3d(
+            x=coords[:, 0],
+            y=coords[:, 1],
+            z=coords[:, 2],
+            mode='markers',
+            marker=dict(size=size, color=color),
+            name=name
+        )
+        self._plotter.add_trace(marker)
+        return self
+
     def show(self):
         """Display plot."""
         self._plotter.show()

--- a/geomfum/wrap/polyscope.py
+++ b/geomfum/wrap/polyscope.py
@@ -50,6 +50,23 @@ class PsMeshPlotter(ShapePlotter):
         )
         return self
 
+    def highlight_vertices(self, coords, color=(1.0, 0.0, 0.0), size=0.01,):
+        """
+        Highlight vertices on a mesh using Polyscope by adding a point cloud.
+
+        Parameters
+        ----------
+        coords : array-like, shape = [n_vertices, 3]
+            Coordinates of vertices to highlight.
+        color : tuple
+            Color of the highlighted vertices (e.g., (1.0, 0.0, 0.0)).
+        radius : float
+            Radius of the rendered points (visual size).
+        """
+        name = 'Highlighted_points'
+        self._plotter.register_point_cloud(name, coords, radius = size, color = color)
+        return self
+
     def show(self):
         """Display plot."""
         self._plotter.show()

--- a/geomfum/wrap/pyvista.py
+++ b/geomfum/wrap/pyvista.py
@@ -56,6 +56,25 @@ class PvMeshPlotter(ShapePlotter):
 
         return self
 
+    def highlight_vertices(self, coords, color='red', size=0.01):
+        """
+        Highlight vertices on the mesh using PyVista.
+
+        Parameters
+        ----------
+        coords : array-like, shape = [n_vertices, 3]
+            Coordinates of vertices to highlight.
+        color : str or tuple
+            Color of the highlighted vertices.
+        size : float
+            Size of the highlighted vertices (radius of spheres).
+        """
+        name = 'Highlighted_points'
+        points = pv.PolyData(coords)
+        glyphs = points.glyph(scale=False, geom=pv.Sphere(radius=size))
+        self._plotter.add_mesh(glyphs, color=color, name=name)
+        return self
+
     def show(self):
         """Display plot."""
         self._add_mesh(self._mesh)

--- a/notebooks/how_to/fps_demo.ipynb
+++ b/notebooks/how_to/fps_demo.ipynb
@@ -1,0 +1,169 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# How to set landmarks?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from geomfum.dataset import NotebooksDataset\n",
+    "from geomfum.metric.mesh import (\n",
+    "    GraphShortestPathMetric,\n",
+    "    HeatDistanceMetric,\n",
+    "    VertexEuclideanMetric,\n",
+    ")\n",
+    "from geomfum.plot import MeshPlotter\n",
+    "from geomfum.sample import FarthestPointSampler\n",
+    "from geomfum.shape import TriangleMesh\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "[Load a mesh](load_mesh_from_file.ipynb)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dataset = NotebooksDataset()\n",
+    "mesh = TriangleMesh.from_file(dataset.get_filename(\"cat-00\"))\n",
+    "dist_functions = []"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Select metrics."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "euc_dist = VertexEuclideanMetric(mesh)\n",
+    "heat_dist = HeatDistanceMetric.from_registry(which=\"pp3d\",shape = mesh)\n",
+    "geo_dist = GraphShortestPathMetric(mesh)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dist_functions = {\n",
+    "    \"euclidean\": euc_dist.dist_from_source,\n",
+    "    \"heat-distance\": heat_dist.dist_from_source,\n",
+    "    \"graph\": geo_dist.dist_from_source,\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Farthest Point Sampling\n",
+    "\n",
+    "The vertex **7181** corresponds to the extreme of the cat’s tail.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fps = {}\n",
+    "for name, dist_func in dist_functions.items():\n",
+    "    samp = FarthestPointSampler(6, dist_func)\n",
+    "    samples = samp.sample(mesh, first_point= 7181)\n",
+    "    fps[name] = samples\n",
+    "    print(f\"FPS {name}: {samples}\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plotter = MeshPlotter.from_registry(colormap=\"RdBu\", which=\"plotly\")\n",
+    "plotter.add_mesh(mesh)\n",
+    "plotter.highlight_vertices(mesh.vertices[fps['euclidean']])\n",
+    "plotter.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plotter = MeshPlotter.from_registry(colormap=\"RdBu\", which=\"pyvista\")\n",
+    "plotter.add_mesh(mesh)\n",
+    "plotter.highlight_vertices(mesh.vertices[fps['heat-distance']])\n",
+    "plotter.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "metric = list(fps.keys())[0]\n",
+    "plotter = MeshPlotter.from_registry(colormap=\"RdBu\", which=\"polyscope\")\n",
+    "plotter.add_mesh(mesh)\n",
+    "plotter.highlight_vertices(mesh.vertices[fps['graph']],)\n",
+    "plotter.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Further reading\n",
+    "\n",
+    "* [How to compute descriptors?](./descriptors.ipynb)\n",
+    "\n",
+    "* [How to set landmarks?](./landmarks.ipynb)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "py12",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
This PR introduces tools and improvements to better support **Farthest Point Sampling (FPS)**, making it independent of the `pyFM` library and enabling consistent visualization across multiple backends.

- User can select distance metric (euclidean, heat, graph) and starting vertex.
- Added ability to select the starting point for FPS.
- Highlights sampled vertices on the mesh in red.
- Implemented highlight_vertices method across backends: `Plotly`, `PyVista`, and `Polyscope`.
- Added FPS visualization demo.