### PR TITLE
Add backend

### DIFF
--- a/geomfum/__init__.py
+++ b/geomfum/__init__.py
@@ -1,1 +1,4 @@
 __version__ = "0.1.0"
+
+
+import geomfum._backend

--- a/geomfum/_backend/__init__.py
+++ b/geomfum/_backend/__init__.py
@@ -1,0 +1,105 @@
+# inspired by geomstats; to be merged there soon
+
+import importlib
+import logging
+import os
+import sys
+import types
+
+
+def get_backend_name():
+    return os.environ.get("GEOMSTATS_BACKEND", "numpy")
+
+
+BACKEND_NAME = get_backend_name()
+
+
+BACKEND_ATTRIBUTES = {
+    "": [
+        "scatter_sum_1d",
+    ],
+}
+
+
+class BackendImporter:
+    """Importer class to create the backend module."""
+
+    def __init__(self, path):
+        self._path = self.name = path
+        self.loader = self
+
+    @staticmethod
+    def _import_backend(backend_name):
+        try:
+            return importlib.import_module(f"geomfum._backend.{backend_name}")
+        except ModuleNotFoundError:
+            raise RuntimeError(f"Unknown backend '{backend_name}'")
+
+    def _create_backend_module(self, backend_name):
+        backend = self._import_backend(backend_name)
+
+        new_module = types.ModuleType(self._path)
+        new_module.__file__ = backend.__file__
+
+        for module_name, attributes in BACKEND_ATTRIBUTES.items():
+            if module_name:
+                try:
+                    submodule = getattr(backend, module_name)
+                except AttributeError:
+                    raise RuntimeError(
+                        f"Backend '{backend_name}' exposes no '{module_name}' module"
+                    ) from None
+                new_submodule = types.ModuleType(f"{self._path}.{module_name}")
+                new_submodule.__file__ = submodule.__file__
+                setattr(new_module, module_name, new_submodule)
+            else:
+                submodule = backend
+                new_submodule = new_module
+
+            for attribute_name in attributes:
+                try:
+                    attribute = getattr(submodule, attribute_name)
+
+                except AttributeError:
+                    if module_name:
+                        error = (
+                            f"Module '{module_name}' of backend '{backend_name}' "
+                            f"has no attribute '{attribute_name}'"
+                        )
+                    else:
+                        error = (
+                            f"Backend '{backend_name}' has no "
+                            f"attribute '{attribute_name}'"
+                        )
+
+                    raise RuntimeError(error) from None
+                else:
+                    setattr(new_submodule, attribute_name, attribute)
+
+        return new_module
+
+    def find_module(self, fullname, path=None):
+        """Find module."""
+        if self._path != fullname:
+            return None
+        return self
+
+    def load_module(self, fullname):
+        """Load module."""
+        if fullname in sys.modules:
+            return sys.modules[fullname]
+
+        module = self._create_backend_module(BACKEND_NAME)
+        module.__name__ = f"geomfum.{BACKEND_NAME}"
+        module.__loader__ = self
+        sys.modules[fullname] = module
+
+        logging.debug(f"geomfum is using {BACKEND_NAME} backend")
+        return module
+
+    def find_spec(self, fullname, path=None, target=None):
+        """Find module."""
+        return self.find_module(fullname, path=path)
+
+
+sys.meta_path.append(BackendImporter("geomfum.backend"))

--- a/geomfum/_backend/numpy/__init__.py
+++ b/geomfum/_backend/numpy/__init__.py
@@ -1,0 +1,15 @@
+import numpy as _np
+import scipy as _scipy
+
+
+def scatter_sum_1d(index, src, size=None):
+    shape = None if size is None else (size, 1)
+
+    dummy_indices = _np.zeros_like(index)
+
+    return _np.array(
+        _scipy.sparse.coo_matrix(
+            (src, (index, dummy_indices)),
+            shape=shape,
+        ).todense()
+    ).flatten()

--- a/geomfum/_backend/pytorch/__init__.py
+++ b/geomfum/_backend/pytorch/__init__.py
@@ -1,0 +1,9 @@
+import torch as _torch
+
+
+def scatter_sum_1d(index, src, size=None):
+    if size is None:
+        size = index.max() + 1
+
+    array = _torch.zeros(size, dtype=src.dtype)
+    return _torch.scatter_add(array, -1, index, src)

--- a/geomfum/io.py
+++ b/geomfum/io.py
@@ -1,3 +1,4 @@
+import geomstats.backend as gs
 import meshio
 
 
@@ -15,7 +16,7 @@ def load_mesh(filename):
     faces : array_like, shape=[n_faces, 3]
     """
     mesh = meshio.read(filename)
-    return mesh.points, mesh.cells[0].data
+    return gs.from_numpy(mesh.points), gs.from_numpy(mesh.cells[0].data)
 
 
 def load_pointcloud(filename):
@@ -31,4 +32,4 @@ def load_pointcloud(filename):
     vertices : array-like, shape=[n_vertices, 3]
     """
     point_cloud = meshio.read(filename)
-    return point_cloud.points
+    return gs.from_numpy(point_cloud.points)

--- a/geomfum/shape/_base.py
+++ b/geomfum/shape/_base.py
@@ -3,7 +3,7 @@
 import abc
 import logging
 
-import numpy as np
+import geomstats.backend as gs
 
 from geomfum.operator import Laplacian
 
@@ -66,7 +66,7 @@ class Shape(abc.ABC):
             Whether to append landmarks to already-existing ones.
         """
         if append:
-            self.landmark_indices = np.stack(self.landmark_indices, landmark_indices)
+            self.landmark_indices = gs.stack(self.landmark_indices, landmark_indices)
 
         else:
             self.landmark_indices = landmark_indices

--- a/geomfum/shape/mesh.py
+++ b/geomfum/shape/mesh.py
@@ -1,8 +1,8 @@
 """Definition of triangle mesh."""
 
-import numpy as np
-import scipy
+import geomstats.backend as gs
 
+import geomfum.backend as gf
 from geomfum.io import load_mesh
 from geomfum.operator import (
     FaceDivergenceOperator,
@@ -26,8 +26,8 @@ class TriangleMesh(Shape):
 
     def __init__(self, vertices, faces):
         super().__init__(is_mesh=True)
-        self.vertices = np.asarray(vertices)
-        self.faces = np.asarray(faces)
+        self.vertices = gs.asarray(vertices)
+        self.faces = gs.asarray(faces)
 
         self._edges = None
         self._face_normals = None
@@ -88,30 +88,41 @@ class TriangleMesh(Shape):
         edges : array-like, shape=[n_edges, 2]
         """
         if self._edges is None:
-            vind012 = np.concatenate(
+            vind012 = gs.concatenate(
                 [self.faces[:, 0], self.faces[:, 1], self.faces[:, 2]]
             )
-            vind120 = np.concatenate(
+            vind120 = gs.concatenate(
                 [self.faces[:, 1], self.faces[:, 2], self.faces[:, 0]]
             )
-
-            E1 = np.concatenate([vind012, vind120])
-            E2 = np.concatenate([vind120, vind012])
-            W = np.ones_like(E1)
-
-            M = scipy.sparse.csr_matrix(
-                (W, (E1, E2)), shape=(self.n_vertices, self.n_vertices)
-            ).tocoo()
-
-            edges0 = M.row
-            edges1 = M.col
-
-            indices = M.col > M.row
-
-            self._edges = np.concatenate(
-                [edges0[indices, None], edges1[indices, None]], axis=1
+            edges = gs.stack(
+                [
+                    gs.concatenate([vind012, vind120]),
+                    gs.concatenate([vind120, vind012]),
+                ],
+                axis=-1,
             )
+            edges = gs.unique(edges, axis=0)
+            self._edges = edges[edges[:, 1] > edges[:, 0]]
+
         return self._edges
+
+    @property
+    def face_vertex_coords(self):
+        """Extract vertex coordinates corresponding to each face.
+
+        Returns
+        -------
+        vertices : array-like, shape=[{n_faces}, n_per_face_vertex, 3]
+            Coordinates of the ith vertex of that face.
+        """
+        return gs.stack(
+            [
+                self.vertices[self.faces[:, 0]],
+                self.vertices[self.faces[:, 1]],
+                self.vertices[self.faces[:, 2]],
+            ],
+            axis=-2,
+        )
 
     @property
     def face_normals(self):
@@ -120,19 +131,29 @@ class TriangleMesh(Shape):
         Returns
         -------
         normals : array-like, shape=[n_faces, 3]
-            Normalized per-face normals.
+            Per-face normals.
         """
         if self._face_normals is None:
-            v1 = self.vertices[self.faces[:, 0]]
-            v2 = self.vertices[self.faces[:, 1]]
-            v3 = self.vertices[self.faces[:, 2]]
-
-            normals = np.cross(v2 - v1, v3 - v1)
-            normals /= np.linalg.norm(normals, axis=1, keepdims=True)
-
-            self._face_normals = normals
+            face_vertex_coords = self.face_vertex_coords
+            self._face_normals = gs.cross(
+                face_vertex_coords[:, 1, :] - face_vertex_coords[:, 0, :],
+                face_vertex_coords[:, 2, :] - face_vertex_coords[:, 0, :],
+            )
 
         return self._face_normals
+
+    @property
+    def unit_face_normals(self):
+        """Compute face normals of a triangular mesh.
+
+        Returns
+        -------
+        normals : array-like, shape=[n_faces, 3]
+            Per-face normals.
+        """
+        return self.face_normals / gs.linalg.norm(
+            self.face_normals, axis=1, keepdims=True
+        )
 
     @property
     def face_areas(self):
@@ -144,10 +165,7 @@ class TriangleMesh(Shape):
             Per-face areas.
         """
         if self._face_areas is None:
-            v1 = self.vertices[self.faces[:, 0]]
-            v2 = self.vertices[self.faces[:, 1]]
-            v3 = self.vertices[self.faces[:, 2]]
-            self._face_areas = 0.5 * np.linalg.norm(np.cross(v2 - v1, v3 - v1), axis=1)
+            self._face_areas = 0.5 * gs.linalg.norm(self.face_normals, axis=1)
 
         return self._face_areas
 
@@ -162,19 +180,15 @@ class TriangleMesh(Shape):
         vertex_areas : array-like, shape=[n_vertices]
             Per-vertex areas.
         """
-        if self._vertex_areas is None:
-            # THIS IS JUST A TRICK TO BE FASTER THAN NP.ADD.AT
-            vind012 = np.concatenate(
-                [self.faces[:, 0], self.faces[:, 1], self.faces[:, 2]]
-            )
-            vind120 = np.zeros_like(vind012)
+        area = self.face_areas
 
-            areas = np.tile(self.face_areas / 3, 3)
-
-            self._vertex_areas = np.array(
-                scipy.sparse.coo_matrix(
-                    (areas, (vind012, vind120)), shape=(self.n_vertices, 1)
-                ).todense()
-            ).flatten()
-
-        return self._vertex_areas
+        id_vertices = gs.broadcast_to(gs.reshape(self.faces, (-1,)), self.n_faces * 3)
+        val = gs.reshape(
+            gs.broadcast_to(gs.expand_dims(area, axis=-1), (self.n_faces, 3)),
+            (-1,),
+        )
+        incident_areas = gf.scatter_sum_1d(
+            index=id_vertices,
+            src=val,
+        )
+        return incident_areas / 3.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,14 @@ classifiers = [
     "Programming Language :: Python :: 3",
 ]
 requires-python = ">= 3.9"
-dependencies = ["numpy", "scipy", "scikit-learn", "meshio", "pyfmaps"]
+dependencies = [
+    "numpy",
+    "scipy",
+    "scikit-learn",
+    "meshio",
+    "pyfmaps",
+    "geomstats@git+https://github.com/geomstats/geomstats.git@main",
+]
 
 [project.optional-dependencies]
 lapl = ["robust-laplacian", "libigl"]
@@ -32,10 +39,16 @@ opt = ["geomfum[lapl,metric,sampling,rematching,sinkhorn]"]
 fun = [
     "geopext@git+https://github.com/luisfpereira/geopext.git@2b7a7be1a8fdc6e5755e5f4bda88bc284065e829",
 ]
-test-scripts = ["nbformat", "nbconvert", "ipykernel", "ipython", "pyvista","plotly"]
+test-scripts = [
+    "nbformat",
+    "nbconvert",
+    "ipykernel",
+    "ipython",
+    "pyvista",
+    "plotly",
+]
 test = [
     "pytest",
-    "geomstats",
     "polpo@git+https://github.com/geometric-intelligence/polpo.git@main",
     "geomfum[opt,test-scripts]",
 ]


### PR DESCRIPTION
This PR starts replacing uses of `np` (and `scipy`) by `gs`, i.e. it starts using a `geomstats` backend-like logic.

To accelerate development, and as mentioned in #51, when `geomstats` backend does not support some functionality we do one of the following:

1. add it to `geomstats` (see e.g. https://github.com/geomstats/geomstats/pull/2054)

2. implement it in `geomfum` own backend, which follows same structure of `geomstats.backend`


Though the changes are relatively simple, here I list some important ones (some for backend compatibility, others for readability/clarity/consistency).

For mesh:

1. edges computation: use of `unique` instead sparse objects (I believe performance might even been increased, but would need to benchmark for very large meshes)

2. add `face_vertex_coords` for clarity

3. add `unit_face_normals` and make `face_normals` not unit (it creates a divergence with `pyfm`, but this seems more natural to me)

4. add `scatter_sum_1d` to backend and use it for `vertex_areas`. Implementation for `numpy` is based on `pyfm` "sparse trick", which is way faster than `numpy.add.at`. torch implements it using `scatter_add`



(I'll bring more changes soon; also need to add tests)

